### PR TITLE
Remove unused helper imports

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -5,7 +5,6 @@ import Tower from '../objects/Tower.js';
 import WaveData from '../data/waveData.js';
 import Gods from '../data/gods.js';
 import GameConfig from '../config/GameConfig.js';
-import { getClosestEnemy, canFire } from '../utils/helpers.js';
 
 export default class GameScene extends Phaser.Scene {
   constructor() {


### PR DESCRIPTION
## Summary
- delete `getClosestEnemy` and `canFire` helper imports from GameScene

## Testing
- `grep -n getClosestEnemy src/scenes/GameScene.js`
- `grep -n canFire src/scenes/GameScene.js`