### PR TITLE
Implement simple tower placement and enemy path

### DIFF
--- a/src/objects/Enemy.js
+++ b/src/objects/Enemy.js
@@ -17,19 +17,47 @@ export default class Enemy extends Phaser.Physics.Arcade.Sprite {
     this.scene.physics.add.existing(this);
     this.setDepth(1);
 
-    // Movement (basic: left to right)
-    this.setVelocityX(this.speed);
+    // Path data
+    this.path = null;
+    this.pathIndex = 0;
 
     // Health bar UI (optional now)
     this.healthBar = this.scene.add.graphics();
     this.updateHealthBar();
   }
 
+  setPath(path) {
+    this.path = path;
+    this.pathIndex = 0;
+    this.moveToNextPoint();
+  }
+
+  moveToNextPoint() {
+    if (!this.path || this.pathIndex >= this.path.length) {
+      this.reachEnd();
+      return;
+    }
+    const point = this.path[this.pathIndex];
+    this.scene.physics.moveTo(this, point.x, point.y, this.speed);
+  }
+
+  reachEnd() {
+    this.healthBar.destroy();
+    this.destroy();
+    this.emit('escape');
+  }
+
   update(time, delta) {
     // Update health bar position
     this.updateHealthBar();
-
-    // You can add path logic here later
+    if (this.path) {
+      const point = this.path[this.pathIndex];
+      const dist = Phaser.Math.Distance.Between(this.x, this.y, point.x, point.y);
+      if (dist < 5) {
+        this.pathIndex++;
+        this.moveToNextPoint();
+      }
+    }
   }
 
   takeDamage(amount, element = null) {

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -1,5 +1,7 @@
 // BootScene.js – Initializes the game and prepares PreloadScene
 
+import GameConfig from '../config/GameConfig.js';
+
 export default class BootScene extends Phaser.Scene {
   constructor() {
     super('BootScene');
@@ -7,7 +9,7 @@ export default class BootScene extends Phaser.Scene {
 
   init() {
     // Set up registry values or config flags
-    this.registry.set('favor', 0);
+    this.registry.set('favor', GameConfig.startingFavor);
     this.registry.set('currentWave', 1);
     this.registry.set('unlockedTiers', ['hero']); // unlocked tiers: hero, demigod, olympian
     console.log('%c[BootScene] Game initializing...', 'color: cyan');

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -15,14 +15,40 @@ export default class GameScene extends Phaser.Scene {
     // Background
     this.add.image(GameConfig.width / 2, GameConfig.height / 2, 'background');
 
+    // Path for enemies
+    this.path = [
+      { x: -50, y: 400 },
+      { x: 200, y: 400 },
+      { x: 200, y: 250 },
+      { x: 824, y: 250 },
+      { x: 824, y: 500 },
+      { x: GameConfig.width + 50, y: 500 }
+    ];
+
     // Groups
     this.enemies = this.physics.add.group();
     this.towers = this.add.group();
     this.projectiles = this.physics.add.group();
 
-    // Place test tower (Zeus)
-    const zeusTower = new Tower(this, 500, 300, Gods.zeus.texture, Gods.zeus);
-    this.towers.add(zeusTower);
+    // HUD
+    this.favorText = this.add.text(16, 16, '', {
+      fontFamily: 'Cinzel',
+      fontSize: '20px',
+      color: '#ffffff'
+    });
+    this.updateHUD();
+
+    // Tower placement
+    this.input.on('pointerdown', pointer => {
+      const config = Gods.zeus;
+      const favor = this.registry.get('favor');
+      if (favor >= config.cost && this.towers.getLength() < GameConfig.maxTowers) {
+        const tower = new Tower(this, pointer.worldX, pointer.worldY, config.texture, config);
+        this.towers.add(tower);
+        this.registry.set('favor', favor - config.cost);
+        this.updateHUD();
+      }
+    });
 
     // Start first wave
     this.currentWave = 0;
@@ -55,12 +81,18 @@ export default class GameScene extends Phaser.Scene {
     wave.enemies.forEach(enemyDef => {
       for (let i = 0; i < enemyDef.count; i++) {
         this.time.delayedCall(enemyDef.delay * i, () => {
-          const enemy = new Enemy(this, 0, 300, enemyDef.texture, enemyDef);
+          const enemy = new Enemy(this, 0, this.path[0].y, enemyDef.texture, enemyDef);
+          enemy.setPath(this.path);
           this.enemies.add(enemy);
 
           enemy.on('death', reward => {
             const oldFavor = this.registry.get('favor');
             this.registry.set('favor', oldFavor + reward);
+            this.updateHUD();
+          });
+
+          enemy.on('escape', () => {
+            console.log('An enemy escaped!');
           });
         });
       }
@@ -70,5 +102,10 @@ export default class GameScene extends Phaser.Scene {
     this.time.delayedCall(1000 * wave.enemies.length + 1000, () => {
       this.waveInProgress = false;
     });
+  }
+
+  updateHUD() {
+    const favor = this.registry.get('favor');
+    this.favorText.setText(`Favor: ${favor}`);
   }
 }


### PR DESCRIPTION
## Summary
- track starting favor using `GameConfig.startingFavor`
- let players place towers by clicking the map
- show favor via a basic HUD
- move enemies along a predefined path

## Testing
- `node -e "require('./src/main.js');" 2>&1 | head` *(fails: Phaser is not defined, expected since Phaser runs in browser)*